### PR TITLE
Apigateway integration

### DIFF
--- a/demo/upload/test/test_upload_lambda.py
+++ b/demo/upload/test/test_upload_lambda.py
@@ -190,14 +190,12 @@ class PutDetailsCase(unittest.TestCase):
 
         test_data = {
         "Identifier": "/2018/fall/Project Upload Repository.pdf",
-        "terms": {
-            "project_name": "Project Upload Repository",
-            "year": "2018",
-            "semester": "Fall",
-            "instructor": "Elentukh",
-            "github": "https://github.com/tglynn/cs673",
-            "description": "A web site hosted using AWS components that stores past CS673 projects for new students to browse and professors to manange."
-            }
+        "project_name": "Project Upload Repository",
+        "year": "2018",
+        "semester": "Fall",
+        "instructor": "Elentukh",
+        "github": "https://github.com/tglynn/cs673",
+        "description": "A web site hosted using AWS components that stores past CS673 projects for new students to browse and professors to manange."
         }
 
         results = commit_details(table, test_data)
@@ -205,7 +203,7 @@ class PutDetailsCase(unittest.TestCase):
         print(results)
         for result in results:
             self.assertEqual(result['Attributes']['project_path'], test_data['Identifier'])
-            self.assertEqual(result['Attributes']['project_name'], test_data['terms']['project_name'])
+            self.assertEqual(result['Attributes']['project_name'], test_data['project_name'])
         table_read = table.get_item(Key= {'project_path': '/2018/fall/Project Upload Repository.pdf'})
         self.assertEqual(table_read['ResponseMetadata']['HTTPStatusCode'], 200)
         

--- a/demo/upload/upload_lambda.py
+++ b/demo/upload/upload_lambda.py
@@ -82,7 +82,8 @@ def upload_file(s3, bucket, path, file_content, content_type, content_encoding):
         path = path[1:]
     object = s3.Object(bucket, path)
     #Decode content string
-    file_content = base64.b64decode(file_content)
+    if content_encoding == 'base64':
+        file_content = base64.b64decode(file_content)
     response = object.put(Body=file_content,
                           ContentEncoding=content_encoding,
                           ContentType=content_type)

--- a/demo/upload/upload_lambda.py
+++ b/demo/upload/upload_lambda.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import boto3
+import base64
 
 loglevel = os.environ.get('LOGLEVEL', 'INFO').upper()
 logger = logging.getLogger()
@@ -48,7 +49,7 @@ def lambda_handler(event, context):
     upload_response = upload_file(s3,
                                   bucket,
                                   r['content-location'],
-                                  r['content']['body'],
+                                  r['content']['encoded_file'],
                                   r['content-type'],
                                   # Get encoding if included. Default
                                   # to utf-8
@@ -80,6 +81,8 @@ def upload_file(s3, bucket, path, file_content, content_type, content_encoding):
     if path[0] == '/':
         path = path[1:]
     object = s3.Object(bucket, path)
+    #Decode content string
+    file_content = base64.b64decode(file_content)
     response = object.put(Body=file_content,
                           ContentEncoding=content_encoding,
                           ContentType=content_type)

--- a/demo/upload/upload_lambda.py
+++ b/demo/upload/upload_lambda.py
@@ -50,11 +50,16 @@ def lambda_handler(event, context):
     detail_response = commit_details(details_table,
     					event['content'])
 
-    if log_clean_results(upload_response, tag_response, detail_response):
-        return "Project uploaded and tagged"
+    if log_clean_results(upload_response, tag_response):
+        return {
+            "statusCode": 200,
+            "body": "Project uploaded and tagged"
+            }
     else:
-        return "Error uploading and tagging project"
-
+        return {
+            "statusCode": 502,
+            "body": "Error uploading and tagging project"
+            }
 
 def upload_file(s3, bucket, path, file_content, content_type, content_encoding):
     """ Uploads a file $file_content of type $content_type and encoding 

--- a/tests/end_to_end_upload.sh
+++ b/tests/end_to_end_upload.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Get the file
+
+echo "Getting file from S3"
+
+curl -O https://s3.us-east-2.amazonaws.com/cs673-projects-folder/2018/Spring/Aurelius+CS633+OL+Spring+2018.pdf
+
+
+echo "Starting file checksum is $(shasum -a 256 ./Aurelius+CS633+OL+Spring+2018.pdf)"
+
+echo "Uploading, tagging and committing"
+
+python ./post_to_apigateway_test.py
+
+echo "Downloading the newly posted file"
+
+curl -O https://s3.us-east-2.amazonaws.com/cs673-projects-folder/2018/Spring/Aurelius+CS633+OL+Spring+2018.pdf
+
+
+echo "Final file checksum is $(shasum -a 256 ./Aurelius+CS633+OL+Spring+2018.pdf)"
+

--- a/tests/post_to_apigateway_test.py
+++ b/tests/post_to_apigateway_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import requests
+import base64
+import json
+import subprocess
+
+API_URL = "https://yh956nkkj5.execute-api.us-east-2.amazonaws.com/default/project_uploader"
+PATH_TO_FILE = "./Aurelius+CS633+OL+Spring+2018.pdf"
+
+with open(PATH_TO_FILE, 'rb') as f:
+    rawbytes = f.read()
+encoded_content = base64.b64encode(rawbytes).decode()
+
+test_data = {
+  "content-location": "/2018/Spring/Aurelius CS633 OL Spring 2018.pdf",
+  "content-type": "application/pdf",
+  "content": {
+    "encoded_file": encoded_content,
+    "encoding": "base64",
+    "tag_data": {
+      "Identifier": [
+        "/2018/Spring/Aurelius CS633 OL Spring 2018.pdf",
+        "Sudoku"
+      ],
+      "terms": {
+        "2018": "year",
+        "Sudoku": "project_name",
+        "Spring": "semester",
+        "Alex Elentukh": "instructor",
+        "javascript": "programming_language",
+        "s3": "framework",
+        "game": "keyword",
+        "cards": "keyword",
+        "matching": "keyword",
+        "git": "version_control"
+      }
+    }
+  }
+}
+
+
+r = requests.post(API_URL, data = json.dumps(test_data))
+
+print(r)
+
+


### PR DESCRIPTION
This PR contains the changes to the upload lambda function to properly integrate with API Gateway.  There was some extra work around file encoding and decoding (since API gateway will only pass json, the file contents had to be base64 encoded before they could get marshalled into the json).


@jskrable, I've also flattened out the dictionary that gets passed to the project details function, and separated it from the terms (they're backwords, so we can't really reuse them; I figure it's easier to just separate them.  In the future, they could be different APIs)



`tests/post_to_apigateway_test.py` is probably the easiest way to see the required structure for the request.  Essentially, when we hit the upload button, we need to POST json with the following structure to our API gateway:

```
{
  "content-location": "/2018/Spring/Aurelius CS633 OL Spring 2018.pdf",
  "content-type": "application/pdf",
  "content": {
    "encoded_file": encoded_content,
    "encoding": "base64",
    "details": {
        "project_name": "Aurelius",
        "year": "2018",
        "semester": "Spring",
        "instructor": "Elentukh",
        "github": "https://github.com/unknownsite",
        "description": "A memory matching game for medical and therapeutic use"
        },
    "tag_data": {
      "Identifier": [
        "/2018/Spring/Aurelius CS633 OL Spring 2018.pdf",
        "Sudoku"
      ],
      "terms": {
        "2018": "year",
        "Sudoku": "project_name",
        "Spring": "semester",
        "Alex Elentukh": "instructor",
        "javascript": "programming_language",
        "s3": "framework",
        "game": "keyword",
        "cards": "keyword",
        "matching": "keyword",
        "git": "version_control"
      }
    }
  }
}

```


The bash script `tests/end_to_end_upload.sh` wraps the `tests/post_to_apigateway_test.py` python script, pulling the project file down from S3, verifying its sha256 checksum, uploading and tagging, then downloading the newly uploaded file and again verifying its sha256 checksum.  Checksum's match, so you can confirm that the upload process is not altering the file.


```
tglynn:tests$ ./end_to_end_upload.sh
Getting file from S3
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2024k  100 2024k    0     0  4302k      0 --:--:-- --:--:-- --:--:-- 4297k
Starting file checksum is b322d285f62c6da6d762bf1bca38d57af6bcdcb695988b18b7b21adcd3a488f8  ./Aurelius+CS633+OL+Spring+2018.pdf
Uploading, tagging and committing
<Response [200]>
Downloading the newly posted file
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2024k  100 2024k    0     0  6670k      0 --:--:-- --:--:-- --:--:-- 6680k
Final file checksum is b322d285f62c6da6d762bf1bca38d57af6bcdcb695988b18b7b21adcd3a488f8  ./Aurelius+CS633+OL+Spring+2018.pdf
```